### PR TITLE
Create TemplateConsoleAppVBNet.vb

### DIFF
--- a/Templates/TemplateConsoleAppVBNet.vb
+++ b/Templates/TemplateConsoleAppVBNet.vb
@@ -1,0 +1,48 @@
+Imports System.Management
+
+Module Module1
+
+    [WMICLASSDESC]
+    Sub Main()
+
+        Dim computerName As String = "localhost"
+        Dim conn As ConnectionOptions = Nothing
+        Dim scope As ManagementScope
+        Dim query As ObjectQuery
+
+        If Not computerName.Equals("localhost", StringComparison.OrdinalIgnoreCase) Then
+            conn = New ConnectionOptions With
+                {
+                    .Username = "",
+                    .Password = "",
+                    .Authority = "ntlmdomain:DOMAIN"
+                }
+        End If
+
+        Try
+            scope = New ManagementScope(String.Format("\\{0}\[WMINAMESPACE]", computerName), options:=If(conn IsNot Nothing, conn, Nothing))
+            scope.Connect()
+
+            query = New ObjectQuery("SELECT * FROM [WMICLASSNAME]")
+
+            Using searcher As New ManagementObjectSearcher(scope, query)
+
+                For Each wmiObject As ManagementObject In searcher.Get()
+
+[VBNETCODE]
+
+                Next wmiObject
+
+            End Using
+
+        Catch ex As Exception
+            Console.WriteLine(String.Format("Exception: {0} Trace: {1}", ex.Message, ex.StackTrace))
+
+        End Try
+
+        Console.WriteLine("Press Enter to exit.")
+        Console.Read()
+
+    End Sub
+
+End Module


### PR DESCRIPTION
VBNet ConsoleApp Template (The equivalent of the C# template sample. A console app with the default entry point method "Main")

Note(s):
· All member names follows strict name conventions to help the compiler recognize the members, please, don't change their string-case.
· conn object is initialized as Nothing to avoid a compiler warning about its usage before being initialized, it shouldn't be changed.