### PR TITLE
Create TemplateEventsVBNET.vb

### DIFF
--- a/Templates/TemplateEventsVBNET.vb
+++ b/Templates/TemplateEventsVBNET.vb
@@ -1,0 +1,60 @@
+Imports System.Management
+
+Namespace GetWmiInfo
+
+    Public NotInheritable Class EventWatcherAsync
+
+        Dim WithEvents watcher As ManagementEventWatcher
+
+        Private Sub Watcher_EventArrived(ByVal sender As Object, ByVal e As EventArrivedEventArgs) Handles watcher.EventArrived
+
+[VBNETEVENTSOUT]
+
+        End Sub
+
+        Public Sub New()
+
+            Console.WriteLine("Listening {0}", "[WMICLASSNAME]")
+            Console.WriteLine("Press Enter to exit.")
+            Me.Initialize()
+            Console.Read()
+
+        End Sub
+
+        Private Sub Initialize()
+
+            Dim computerName As String = "localhost"
+            Dim conn As ConnectionOptions = Nothing
+            Dim wmiQuery As String
+            Dim scope As ManagementScope
+
+            If Not computerName.Equals("localhost", StringComparison.OrdinalIgnoreCase) Then
+                conn = New ConnectionOptions With
+                    {
+                        .Username = "",
+                        .Password = "",
+                        .Authority = "ntlmdomain:DOMAIN"
+                    }
+            End If
+
+            Try
+                scope = New ManagementScope(String.Format("\\{0}\[WMINAMESPACE]", computerName), options:=If(conn IsNot Nothing, conn, Nothing))
+                scope.Connect()
+
+[VBNETEVENTSWQL]
+
+                Me.watcher = New ManagementEventWatcher(scope, New EventQuery(wmiQuery))
+                Me.watcher.Start()
+                Console.Read()
+                Me.watcher.Stop()
+
+            Catch ex As Exception
+                Console.WriteLine(String.Format("Exception: {0} Trace: {1}", ex.Message, ex.StackTrace))
+
+            End Try
+
+        End Sub
+
+    End Class
+
+End Namespace


### PR DESCRIPTION
VBNet Event-Handler Template (The equivalent of the C# template sample. A custom class with a custom Namespace)

Note(s):
· All member names follows strict name conventions to help the compiler recognize the members, please, don't change their string-case.
· conn object is initialized as Nothing to avoid a compiler warning about its usage before being initialized, it shouldn't be changed.